### PR TITLE
Make App archive consistently reproducible

### DIFF
--- a/internal/publish.go
+++ b/internal/publish.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v2"
 
@@ -171,6 +172,11 @@ func createTgz(composeContent []byte, appDir string) ([]byte, error) {
 				return fmt.Errorf("Tar: Can't tar non regular types yet: %s", header.Name)
 			}
 		}
+		// reset the file's timestamps, otherwise hashes of the resultant TGZs will differ
+		// even if their content is the same
+		header.ChangeTime = time.Time{}
+		header.AccessTime = time.Time{}
+		header.ModTime = time.Time{}
 
 		if err := tw.WriteHeader(header); err != nil {
 			return err


### PR DESCRIPTION
Reset timestamps of App's files, otherwise produced App tgz as well as
its hash will differ even if App's content is the same. It's caused by
the fact that App's files have timestamps equal to the time of checking
out of a container repo by the CI job.

Signed-off-by: Mike Sul <mike.sul@foundries.io>