### PR TITLE
Include hash of each service's configuration

### DIFF
--- a/internal/publish.go
+++ b/internal/publish.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"os"
@@ -44,7 +45,7 @@ func PinServiceImages(cli *client.Client, ctx context.Context, services map[stri
 	return iterateServices(services, proj, func(s compose.ServiceConfig) error {
 		name := s.Name
 		obj := services[name]
-		svc, ok := obj.(map[string]interface{})
+		svc := obj.(map[string]interface{})
 
 		image := s.Image
 		if len(image) == 0 {
@@ -103,6 +104,30 @@ func PinServiceImages(cli *client.Client, ctx context.Context, services map[stri
 
 		fmt.Println("\n  |-> ", pinned)
 		svc["image"] = pinned
+		return nil
+	})
+}
+
+func PinServiceConfigs(cli *client.Client, ctx context.Context, services map[string]interface{}, proj *compose.Project) error {
+	return iterateServices(services, proj, func(s compose.ServiceConfig) error {
+		obj := services[s.Name]
+		svc := obj.(map[string]interface{})
+
+		marshalled, err := yaml.Marshal(s)
+		if err != nil {
+			return err
+		}
+
+		labels, ok := svc["labels"]
+		if !ok {
+			labels = make(map[string]interface{})
+			svc["labels"] = labels
+		}
+		h := sha256.New()
+		if _, err := h.Write(marshalled); err != nil {
+			return fmt.Errorf("Unexpected error hashing service config for %s", s.Name)
+		}
+		labels.(map[string]interface{})["io.compose-spec.config-hash"] = fmt.Sprintf("%x", h.Sum(nil))
 		return nil
 	})
 }

--- a/main.go
+++ b/main.go
@@ -124,6 +124,11 @@ func doPublish(file, target, digestFile string, dryRun bool) error {
 		return err
 	}
 
+	fmt.Println("= Hashing services")
+	if err := internal.PinServiceConfigs(cli, ctx, svcs.(map[string]interface{}), proj); err != nil {
+		return err
+	}
+
 	fmt.Println("= Publishing app...")
 	dgst, err := internal.CreateApp(ctx, config, target, dryRun)
 	if err != nil {


### PR DESCRIPTION
Although we don't wanna/need to use it for a decision whether to sync or not App I think it's useful in terms of reporting, it provides one more item to simplify debugging/troubleshooting and understanding the current state of Apps.

Also, we just lucky that this https://github.com/foundriesio/aktualizr-lite/blob/1cfc6e6dbc7aa358effc7334c6f861dc30c2332e/src/docker/dockerclient.cc#L39 returns an empty string if there is no such label in container metadata, so removing of the given commit without adjusting aklite didn't cause any issue, otherwise aklite could keep restarting Apps :).

This allows a user to run `docker ps` type commands to verify the
correct compose app service is active.

Signed-off-by: Andy Doan <andy@foundries.io>