### PR TITLE
Remove build stanza from services

### DIFF
--- a/internal/publish.go
+++ b/internal/publish.go
@@ -54,6 +54,10 @@ func PinServiceImages(cli *client.Client, ctx context.Context, services map[stri
 		if len(image) == 0 {
 			return fmt.Errorf("Service(%s) missing 'image' attribute", name)
 		}
+		if s.Build != nil {
+			fmt.Printf("Removing service(%s) 'build' stanza\n", name)
+			delete(svc, "build")
+		}
 
 		fmt.Printf("Pinning %s(%s)\n", name, image)
 		named, err := reference.ParseNormalizedNamed(image)


### PR DESCRIPTION
A build stanza doesn't make sense in the scope of a compose app.
However, they can be handy for local development. Removing while
publishing helps prevent a device from accidentally trying to build
rather than pull.

Signed-off-by: Andy Doan <andy@foundries.io>