### PR TITLE
Add support of architecture shortlisting

### DIFF
--- a/cmd/fioapp/main.go
+++ b/cmd/fioapp/main.go
@@ -10,14 +10,17 @@ import (
 	"github.com/foundriesio/compose-publish/pkg/fioapp"
 	"log"
 	"path/filepath"
+	"strings"
 )
 
 func main() {
 	var composeFile string
 	var appRef string
+	var archListStr string
 
 	flag.StringVar(&composeFile, "compose-file", "docker-compose.yml", "A path to a compose file")
 	flag.StringVar(&appRef, "app-ref", "", "A reference to App's Registry Repo")
+	flag.StringVar(&archListStr, "arch-list", "", "An architecture list")
 	flag.Parse()
 
 	if len(appRef) == 0 {
@@ -37,7 +40,11 @@ func main() {
 
 	ctx := context.Background()
 
-	appLayers, err := fioapp.GetAppLayers(ctx, appServices)
+	var archList []string
+	if len(archListStr) > 0 {
+		archList = strings.Split(archListStr, ",")
+	}
+	appLayers, err := fioapp.GetAppLayers(ctx, appServices, archList)
 	if err != nil {
 		log.Fatalf("failed to get App layers: %s", err.Error())
 	}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	commandLine "github.com/urfave/cli/v2"
 
@@ -53,7 +54,15 @@ func main() {
 			if len(target) == 0 {
 				return errors.New("Missing required argument: TARGET:[TAG]")
 			}
-			return pkg.DoPublish(file, target, digestFile, dryRun)
+			var archList []string
+			archListStr := c.Args().Get(1)
+			if len(archListStr) == 0 {
+				log.Println("Architecture list is not specified," +
+					" intersection of all App's images architectures will be supported by App")
+			} else {
+				archList = strings.Split(archListStr, ",")
+			}
+			return pkg.DoPublish(file, target, digestFile, dryRun, archList)
 		},
 	}
 


### PR DESCRIPTION
- Shortlist App's supported architectures by a given input arch
shortlist.
- Make sure that a number of architectures doesn't exceed 6 and App
manifest size doesn't exceed 2010 (old aklite requirement).

Signed-off-by: Mike Sul <mike.sul@foundries.io>