### PR TITLE
Add a CLI flag to pass digested image URIs

### DIFF
--- a/internal/publish.go
+++ b/internal/publish.go
@@ -50,7 +50,7 @@ func iterateServices(services map[string]interface{}, proj *compose.Project, fn 
 	})
 }
 
-func PinServiceImages(cli *client.Client, ctx context.Context, services map[string]interface{}, proj *compose.Project) error {
+func PinServiceImages(cli *client.Client, ctx context.Context, services map[string]interface{}, proj *compose.Project, pinnedImages map[string]digest.Digest) error {
 	regc := NewRegistryClient()
 
 	return iterateServices(services, proj, func(s compose.ServiceConfig) error {
@@ -90,7 +90,10 @@ func PinServiceImages(cli *client.Client, ctx context.Context, services map[stri
 		case reference.Digested:
 			digest = v.Digest()
 		default:
-			return fmt.Errorf("Invalid reference type for %s: %T. Images must be pinned to a `:<tag>` or `@sha256:<hash>`", named, named)
+			var ok bool
+			if digest, ok = pinnedImages[named.Name()]; !ok {
+				return fmt.Errorf("Invalid reference type for %s: %T. Images must be pinned to a `:<tag>` or `@sha256:<hash>`", named, named)
+			}
 		}
 
 		mansvc, err := repo.Manifests(ctx, nil)

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/opencontainers/go-digest"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -42,7 +43,7 @@ func loadProj(file string, content []byte) (*compose.Project, error) {
 	})
 }
 
-func DoPublish(file, target, digestFile string, dryRun bool, archList []string) error {
+func DoPublish(file, target, digestFile string, dryRun bool, archList []string, pinnedImages map[string]digest.Digest) error {
 	b, err := ioutil.ReadFile(file)
 	if err != nil {
 		return err
@@ -68,7 +69,7 @@ func DoPublish(file, target, digestFile string, dryRun bool, archList []string) 
 	if !ok {
 		return errors.New("Unable to find 'services' section of compose file")
 	}
-	if err := internal.PinServiceImages(cli, ctx, svcs.(map[string]interface{}), proj); err != nil {
+	if err := internal.PinServiceImages(cli, ctx, svcs.(map[string]interface{}), proj, pinnedImages); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If digested URIs of service images are known then pass them via CLI flag, and make use of them if not pinned image reference is found in a compose project/file.

Signed-off-by: Mike <mike.sul@foundries.io>