### PR TITLE
WIP: Publish App layers metadata

### DIFF
--- a/cmd/fioapp/main.go
+++ b/cmd/fioapp/main.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/compose-spec/compose-go/cli"
-	"github.com/compose-spec/compose-go/types"
-	"github.com/foundriesio/compose-publish/pkg/fioapp"
 	"log"
 	"path/filepath"
 	"strings"
+
+	"github.com/compose-spec/compose-go/cli"
+	"github.com/compose-spec/compose-go/types"
+	"github.com/foundriesio/compose-publish/pkg/fioapp"
 )
 
 func main() {
@@ -59,7 +60,7 @@ func main() {
 		}
 	}
 
-	layerManifests, err := fioapp.PostAppLayersManifests(ctx, appRef, appLayers)
+	layerManifests, err := fioapp.PostAppLayersManifests(ctx, appRef, appLayers, false)
 	if err != nil {
 		log.Fatalf("failed to generate or post App layers manifest: %s", err.Error())
 	}

--- a/main.go
+++ b/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/docker/distribution/reference"
-	"github.com/opencontainers/go-digest"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/docker/distribution/reference"
+	"github.com/opencontainers/go-digest"
 
 	commandLine "github.com/urfave/cli/v2"
 
@@ -25,6 +26,7 @@ func main() {
 	var digestFile string
 	var dryRun bool
 	var pinnedImageURIs []string
+	var layersMetaFile string
 
 	fmt.Print(banner)
 	app := &commandLine.App{
@@ -60,6 +62,13 @@ func main() {
 				},
 				Destination: &pinnedImageURIs,
 			},
+			&commandLine.StringFlag{
+				Name:        "layers-meta",
+				Aliases:     []string{"l"},
+				Required:    false,
+				Usage:       "Json file containing App layers' metadata (size, usage)",
+				Destination: &layersMetaFile,
+			},
 		},
 		Action: func(c *commandLine.Context) error {
 			target := c.Args().Get(0)
@@ -86,7 +95,7 @@ func main() {
 					return errors.New("Image URI specified in `pinned-images` is not digested: " + uri)
 				}
 			}
-			return pkg.DoPublish(file, target, digestFile, dryRun, archList, pinnedImages)
+			return pkg.DoPublish(file, target, digestFile, dryRun, archList, pinnedImages, layersMetaFile)
 		},
 	}
 


### PR DESCRIPTION
Extend the publish tool to include app layers metadata into the app manifest.