### PR TITLE
pkg/publish: Don't exit if layer meta is missing

### DIFF
--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -105,7 +105,7 @@ func DoPublish(file, target, digestFile string, dryRun bool, archList []string, 
 		fmt.Println("= Getting app layers metadata...")
 		appLayersMetaBytes, err = fioapp.GetAppLayersMeta(layersMetaFile, appLayers)
 		if err != nil {
-			return err
+			fmt.Printf("= Failed to get app layers metadata: %s\n", err.Error())
 		}
 	}
 


### PR DESCRIPTION
In some cases layers metadata that are supposed to be gathered in the container CI run are not present for each app layer, or some of the app layers has changed after the container run completion and before running the publish run.
Also, it seems like the logic in the build CI may pull app image layer different than the publish run pulls for images stored in 3rd party registries (to be investigated).
Having app layers metadata is an optional since aklite falls back to usage of the approximate approach to calculate app update diff. Therefore, the publish run should not fail if inconsistency between app layers gathered by the build and publish run is found.